### PR TITLE
Migrate Greycliff CF font CDN from DigitalOcean to Cloudflare R2

### DIFF
--- a/src/styles/typeface-greycliff.css
+++ b/src/styles/typeface-greycliff.css
@@ -1,8 +1,8 @@
 @font-face {
   font-family: 'Greycliff CF';
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-Regular.eot'); /* IE9 Compat Modes */
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-Regular.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-Regular.woff') format('woff');
+  src: url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-Regular.eot'); /* IE9 Compat Modes */
+  src: url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-Regular.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-Regular.woff') format('woff');
   font-style: normal;
   font-weight: 400;
   text-rendering: optimizeLegibility;
@@ -10,9 +10,9 @@
 
 @font-face {
   font-family: 'Greycliff CF';
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-RegularOblique.eot'); /* IE9 Compat Modes */
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-RegularOblique.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-RegularOblique.woff') format('woff');
+  src: url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-RegularOblique.eot'); /* IE9 Compat Modes */
+  src: url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-RegularOblique.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-RegularOblique.woff') format('woff');
   font-style: italic;
   font-weight: 400;
   text-rendering: optimizeLegibility;
@@ -20,9 +20,9 @@
 
 @font-face {
   font-family: 'Greycliff CF';
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-Medium.eot'); /* IE9 Compat Modes */
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-Medium.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-Medium.woff') format('woff');
+  src: url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-Medium.eot'); /* IE9 Compat Modes */
+  src: url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-Medium.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-Medium.woff') format('woff');
   font-style: normal;
   font-weight: 500;
   text-rendering: optimizeLegibility;
@@ -30,9 +30,9 @@
 
 @font-face {
   font-family: 'Greycliff CF';
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-MediumOblique.eot'); /* IE9 Compat Modes */
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-MediumOblique.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-MediumOblique.woff') format('woff');
+  src: url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-MediumOblique.eot'); /* IE9 Compat Modes */
+  src: url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-MediumOblique.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-MediumOblique.woff') format('woff');
   font-style: italic;
   font-weight: 500;
   text-rendering: optimizeLegibility;
@@ -40,9 +40,9 @@
 
 @font-face {
   font-family: 'Greycliff CF';
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBold.eot'); /* IE9 Compat Modes */
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBold.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBold.woff') format('woff');
+  src: url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBold.eot'); /* IE9 Compat Modes */
+  src: url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBold.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBold.woff') format('woff');
   font-style: normal;
   font-weight: 600;
   text-rendering: optimizeLegibility;
@@ -50,9 +50,9 @@
 
 @font-face {
   font-family: 'Greycliff CF';
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBoldOblique.eot'); /* IE9 Compat Modes */
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBoldOblique.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBoldOblique.woff') format('woff');
+  src: url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBoldOblique.eot'); /* IE9 Compat Modes */
+  src: url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBoldOblique.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBoldOblique.woff') format('woff');
   font-style: italic;
   font-weight: 600;
   text-rendering: optimizeLegibility;

--- a/src/styles/typeface-greycliff.css
+++ b/src/styles/typeface-greycliff.css
@@ -1,8 +1,8 @@
 @font-face {
   font-family: 'Greycliff CF';
-  src: url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-Regular.eot'); /* IE9 Compat Modes */
-  src: url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-Regular.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-Regular.woff') format('woff');
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-Regular.eot'); /* IE9 Compat Modes */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-Regular.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-Regular.woff') format('woff');
   font-style: normal;
   font-weight: 400;
   text-rendering: optimizeLegibility;
@@ -10,9 +10,9 @@
 
 @font-face {
   font-family: 'Greycliff CF';
-  src: url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-RegularOblique.eot'); /* IE9 Compat Modes */
-  src: url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-RegularOblique.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-RegularOblique.woff') format('woff');
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-RegularOblique.eot'); /* IE9 Compat Modes */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-RegularOblique.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-RegularOblique.woff') format('woff');
   font-style: italic;
   font-weight: 400;
   text-rendering: optimizeLegibility;
@@ -20,9 +20,9 @@
 
 @font-face {
   font-family: 'Greycliff CF';
-  src: url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-Medium.eot'); /* IE9 Compat Modes */
-  src: url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-Medium.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-Medium.woff') format('woff');
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-Medium.eot'); /* IE9 Compat Modes */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-Medium.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-Medium.woff') format('woff');
   font-style: normal;
   font-weight: 500;
   text-rendering: optimizeLegibility;
@@ -30,9 +30,9 @@
 
 @font-face {
   font-family: 'Greycliff CF';
-  src: url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-MediumOblique.eot'); /* IE9 Compat Modes */
-  src: url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-MediumOblique.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-MediumOblique.woff') format('woff');
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-MediumOblique.eot'); /* IE9 Compat Modes */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-MediumOblique.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-MediumOblique.woff') format('woff');
   font-style: italic;
   font-weight: 500;
   text-rendering: optimizeLegibility;
@@ -40,9 +40,9 @@
 
 @font-face {
   font-family: 'Greycliff CF';
-  src: url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-DemiBold.eot'); /* IE9 Compat Modes */
-  src: url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-DemiBold.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-DemiBold.woff') format('woff');
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBold.eot'); /* IE9 Compat Modes */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBold.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBold.woff') format('woff');
   font-style: normal;
   font-weight: 600;
   text-rendering: optimizeLegibility;
@@ -50,9 +50,9 @@
 
 @font-face {
   font-family: 'Greycliff CF';
-  src: url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-DemiBoldOblique.eot'); /* IE9 Compat Modes */
-  src: url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-DemiBoldOblique.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/greycliff-cf-v2.0/GreycliffCF-DemiBoldOblique.woff') format('woff');
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBoldOblique.eot'); /* IE9 Compat Modes */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBoldOblique.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dr-saavedra/fonts/greycliff-cf-v2.0/GreycliffCF-DemiBoldOblique.woff') format('woff');
   font-style: italic;
   font-weight: 600;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Summary
Updated all font file URLs in the Greycliff CF typeface stylesheet to use a new Cloudflare R2 CDN endpoint instead of the previous DigitalOcean Spaces CDN.

## Changes
- Migrated font CDN from `https://fsvdr-fonts.sfo2.cdn.digitaloceanspaces.com/` to `https://pub-dba0a7ed9ee84bcaa39a9591a0baf63a.r2.dev/`
- Updated all 6 `@font-face` declarations (Regular, RegularOblique, Medium, MediumOblique, DemiBold, DemiBoldOblique)
- Each font variant has 2-3 URL references that were updated (eot, eot with iefix, and woff formats)

## Details
This change maintains the same font file structure and naming (`greycliff-cf-v2.0/`) while switching the underlying CDN provider. All font formats and weights remain unchanged, ensuring no visual or functional impact on the application.

https://claude.ai/code/session_0193XjAmcTBsx6tJuGCaH18U